### PR TITLE
Add luxon locale default settings

### DIFF
--- a/src/components/common/DateTimeView/DateTimeView.tsx
+++ b/src/components/common/DateTimeView/DateTimeView.tsx
@@ -1,4 +1,4 @@
-import { DateTime } from 'luxon';
+import { DateTime, Settings } from 'luxon';
 import React from 'react';
 
 type DateTimeViewType = 'date' | 'time' | 'datetime' | 'datetimeWithWeekday';
@@ -22,7 +22,9 @@ const DateTimeView: React.FC<DateTimeViewProps> = ({
   value,
 }) => {
   const format = formatMap[type] || DateTime.DATE_FULL;
-  return <>{value?.toLocaleString(format)}</>;
+  return (
+    <>{value?.toLocaleString(format, { locale: Settings.defaultLocale })}</>
+  );
 };
 
 export { DateTimeView };

--- a/src/context/SettingsContext.tsx
+++ b/src/context/SettingsContext.tsx
@@ -1,5 +1,6 @@
 import { PublicKey } from '@ergolabs/ergo-sdk';
 import { useLocalStorage } from '@rehooks/local-storage';
+import { Settings as LuxonSettings } from 'luxon';
 import React, { createContext, useContext, useEffect } from 'react';
 
 import { MIN_NITRO } from '../common/constants/erg';
@@ -88,6 +89,10 @@ export const SettingsProvider = ({
       });
     }
   }, []);
+
+  useEffect(() => {
+    LuxonSettings.defaultLocale = userSettings.lang;
+  }, [userSettings.lang]);
 
   // useEffect(() => {
   //   if (!usedAddresses || !unusedAddresses) {


### PR DESCRIPTION
We need to rethink about existing luxon dates.
Luxon DateTime keeps old locale inside existing objects.
After switching language need to recreate them.
TBD