### PR TITLE
Fix broken "How to Use" link 

### DIFF
--- a/src/components/common/Layout/Header/BurgerMenu/BurgerMenu.tsx
+++ b/src/components/common/Layout/Header/BurgerMenu/BurgerMenu.tsx
@@ -64,7 +64,7 @@ const BurgerMenu = (): JSX.Element => {
     {
       title: t`How to use`,
       icon: <QuestionCircleOutlined />,
-      link: 'https://docs.spectrum.io/docs/user-guides/quick-start',
+      link: 'https://docs.spectrum.fi/docs/user-guides/quick-start',
       onClick: () => panalytics.clickBurgerMenu('How to use'),
     },
     {


### PR DESCRIPTION
The "how to use" link on the DEX page was incorrectly pointing to spectrum.io, which is a broken link. This fixes that problem.